### PR TITLE
Changed white point to the brightest white

### DIFF
--- a/TestRGBLabConverter.java
+++ b/TestRGBLabConverter.java
@@ -13,9 +13,14 @@ public class TestRGBLabConverter {
 		try {
 			// Set the white point 
 			Vector<Double> D65 = new Vector<Double>();
-			D65.add(95.047);
+			/*D65.add(95.047);
 			D65.add(100.0);
-			D65.add(108.883);
+			D65.add(108.883);*/
+			// White point found by multiplying the RGB to XYZ matrix provided 
+			// by <1.0, 1.0, 1.0> 
+			D65.add(25.376467605);
+			D65.add(52.603498246);
+			D65.add(55.729080359);
 			
 			// Create the color converter using the matrices and model loaded from files 
 			RGBLabConverter converter = new RGBLabConverter("DisplayMeasurement\\dell_s2240m_matrices.csv", "DisplayMeasurement\\model.csv", D65);


### PR DESCRIPTION
Dr. Brinkman,

I changed the white point to the value we discussed today (I multiplied the RGB to XYZ matrix by <1.0, 1.0, 1.0>). I think it helped with the RGB to Lab conversion, but the Lab to RGB conversion still does not seem correct. I tested it how you suggested and converted an RGB color to Lab and then back again. The red component was very close, but the green and blue components became 0. I took a very quick look at the code and nothing obvious jumped out at me (I mainly looked at the equations for Lab to XYZ to make sure I had them correct), so would you mind taking another look? Thanks!